### PR TITLE
Replace discord.js-selfbot-v13 with a native Discord Gateway client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Discord Status Spoofer:
 I want my Discord status to be set as one status and to not update.
-This is a Python program (using discord.py-self) with a React frontend to pick a status. 
+This is a Node/Express program with a React frontend to pick a status. It
+speaks the official Discord Gateway protocol directly (`lib/discord-gateway.js`)
+using Node's built-in WebSocket — no selfbot library involved.
 
 ![demo](/readme_resources/example.gif)
 
@@ -13,6 +15,10 @@ This is a Python program (using discord.py-self) with a React frontend to pick a
 2. `cd discord-spoofer-frontend` and `npm i`
 3. `npm run build`
 4. return to project root and `node index.js`
+
+# Testing
+`npm test` runs the gateway protocol + API surface tests (no token or network
+needed).
 
 
 

--- a/docs/plan-native-gateway.md
+++ b/docs/plan-native-gateway.md
@@ -1,0 +1,81 @@
+# Plan: Replace `discord.js-selfbot-v13` with a native Gateway client
+
+## Goal
+Remove the unmaintained `discord.js-selfbot-v13` dependency by speaking the
+official Discord Gateway protocol directly (the same protocol the official web
+client uses to set your status). No new runtime dependencies: the Docker image
+runs Node 24, which has a built-in global `WebSocket`.
+
+## Background / constraints
+- Discord has **no REST endpoint for presence**. Status can only be changed via
+  Gateway opcode 4 (`Update Status`). Confirmed against the official API docs.
+- The app currently uses only 3 things from the library (all in `index.js`):
+  1. `client.user.presence.status` → read current status
+  2. `client.user.setPresence({ status, afk })` → change status
+  3. `ready` / `shardReady` events → initial connect + resume logic
+- The frontend only talks to `/api/getStatus` and `/api/updateStatus`, so the
+  Express surface must stay identical.
+
+## Design
+
+### New file: `lib/discord-gateway.js`
+A small `DiscordGateway` class extending `EventEmitter`:
+
+- `connect()`
+  1. `GET https://discord.com/api/v10/gateway` → base ws URL
+  2. Open `WebSocket` to `${url}?v=10&encoding=json`
+  3. On `HELLO` (op 10): start heartbeat timer, send `IDENTIFY` (op 2) with
+     token, `GUILD_PRESENCES` intent (bit 8), and initial presence
+  4. On `READY` (op 0 dispatch): store `session_id` + user id, emit `ready`
+- Heartbeat: op 1 every `heartbeat_interval`, last `seq` (null before any
+  dispatch). Handle server-requested heartbeats (op 1) immediately. If no
+  `HEARTBEAT ACK` (op 11) arrives within 2× the interval, force a reconnect.
+- `setPresence(status, afk)` → send op 4
+  `{"status": <s>, "afk": <a>, "since": null, "activities": []}`.
+  Rejects if not connected. Resolves once the frame is sent.
+- Status tracking: `this.status` is set optimistically by `setPresence` and
+  reconciled from `PRESENCE_UPDATE` dispatches for our own user id.
+- Reconnect: on `RECONNECT` (op 7), close (4000/4001/4002/4009/10xx) or
+  zombie-detection, reconnect with exponential backoff (1s → 30s).
+  If a `session_id` exists, send `RESUME` (op 6) with last `seq`; on
+  `RESUMED` dispatch emit `resumed`. If no `RESUMED` within 30s, re-identify.
+- Failure: close code 4004 (auth failed) or `INVALID SESSION` (op 9,
+  `d === false`) → emit `fatal` (index.js exits, docker restarts cleanly).
+
+### `index.js` (behavior-preserving rewire)
+| Old (selfbot library)            | New (gateway client)             |
+|----------------------------------|----------------------------------|
+| `client.user.presence.status`    | `gateway.status`                 |
+| `client.user.setPresence({...})` | `await gateway.setPresence(s,a)` |
+| `client.on('ready')`             | `gateway.on('ready')`            |
+| `client.on('shardReady')`        | `gateway.on('resumed')`          |
+| `client.login(TOKEN)`            | `gateway.connect()`              |
+
+`statusAlreadySet` / `lastStatus` / `lastAfk` and the resume-on-reconnect
+behavior (restore last status, else `invisible`) stay exactly the same.
+
+### Tests: `test/gateway.test.js`
+`node:test` + a mock WebSocket implementing the protocol (HELLO → READY →
+acks → PRESENCE_UPDATE, plus RESUME flow). Covers: identify payload,
+heartbeat cadence, setPresence frame + status tracking, server presence
+reconcile, resume with session_id, 4004 fatal. Runs with `node --test` —
+no real token needed.
+
+### Housekeeping
+- `package.json`: drop `discord.js-selfbot-v13`; regenerate lockfile.
+- `README.md`: correct the stale "Python / discord.py-self" description.
+
+## Out of scope
+- ToS status is unchanged: a personal token over the Gateway is still a
+  self-bot (see README). This only removes the old library.
+- Sharding (never used), compression, activity/emoji presence, afk push
+  notifications.
+
+## Commit cadence
+1. Plan (this file)
+2. Gateway core: connect / identify / heartbeat
+3. Presence update + status tracking
+4. Resume / reconnect / failure handling
+5. Tests (mock WebSocket)
+6. Rewire `index.js` + drop dependency
+7. README touch-up

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 require('dotenv').config()
 
 const express = require("express");
-const cors = require("cors");
 const path = require("path");
 const CLIENT_FRONTEND_PATH = path.join(__dirname, "./", "discord-spoofer-frontend", "dist");
 const PORT = process.env.PORT;
@@ -10,9 +9,9 @@ const PORT = process.env.PORT;
 const app = express();
 app.use(express.json());
 
-const { Client } = require('discord.js-selfbot-v13');
+const { DiscordGateway } = require('./lib/discord-gateway');
 const TOKEN = process.env.TOKEN;
-const client = new Client();
+const gateway = new DiscordGateway({ token: TOKEN });
 
 var statusAlreadySet = false;
 var lastStatus = null;
@@ -39,9 +38,11 @@ const prepareApp = async () => {
 app.get('/api/getStatus', async (req, res) => {
     console.log('GET: /api/status')
     try {
-        const presence = client.user.presence;
+        if (!gateway.ready) {
+            throw new Error('gateway not ready');
+        }
         res.json({
-            currentStatus: presence.status
+            currentStatus: gateway.status
         })
     } catch {
         res.status(500);
@@ -50,7 +51,7 @@ app.get('/api/getStatus', async (req, res) => {
 
 });
 
-// update the status {newStatus: "status", isAfk: bool} 
+// update the status {newStatus: "status", isAfk: bool}
 // isAfk is a leftover from the python version, i don't think discord.js supports this?
 app.post('/api/updateStatus', async (req, res) => {
     try {
@@ -69,41 +70,45 @@ app.post('/api/updateStatus', async (req, res) => {
 
 
 /**
- * change status 
+ * change status
  * @param {string} newStatus 'online', 'idle', 'dnd', 'invisible'
  * @param {boolean} isAfk afk to decide if Discord should send a push notification to mobile
  */
 const changeStatus = async (newStatus, isAfk = true) => {
     // 'online', 'idle', 'dnd', 'invisible'
     console.log(`Changing status to: ${newStatus}`)
-    client.user.setPresence(
-        {
-            status: newStatus,
-            afk: isAfk
-        }
-    ) // https://discordjs-self-v13.netlify.app/#/docs/docs/main/typedef/PresenceData
+    await gateway.setPresence(newStatus, isAfk)
     statusAlreadySet = true;
     lastStatus = newStatus;
     lastAfk = isAfk;
 }
 
-client.on('ready', async () => {
-    console.log(`${client.user.username} is ready!`);
+gateway.on('ready', (user) => {
+    console.log(`${user.username} is ready!`);
     changeStatus('online', true); // just default status as online
-
-
 })
-// idk which one to use https://gist.github.com/Iliannnn/6c69605cb6b8cc03f0ab9c885fd39906#apirequest
-client.on('shardReady', (id) => {
+
+// fires when the session is resumed after a reconnect. restore the last
+// status we set, or default to invisible if we never set one.
+gateway.on('resumed', () => {
     if (statusAlreadySet) {
         console.log(`resuming ${lastStatus}`)
         changeStatus(lastStatus, lastAfk)
     } else {
         changeStatus('invisible', true); // default as invisible when resuming
     }
-});
+})
 
-client.login(TOKEN);
+// auth failure (bad token): log and exit so the container restarts cleanly.
+gateway.on('fatal', (err) => {
+    console.error('fatal gateway error:', err.message);
+    process.exit(1);
+})
+
+gateway.connect().catch((err) => {
+    console.error('gateway connect failed:', err.message);
+    process.exit(1);
+});
 
 
 prepareApp();

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -36,6 +36,13 @@ const OPCODE = Object.freeze({
 /** Intents requested at IDENTIFY time: GUILDS (1) | GUILD_PRESENCES (8). */
 const INTENTS = (1 << 0) | (1 << 3);
 
+/** Presence statuses accepted by the gateway. */
+const VALID_STATUSES = new Set(["online", "idle", "dnd", "invisible"]);
+
+/**
+ * @typedef {"online"|"idle"|"dnd"|"invisible"} PresenceStatus
+ */
+
 /** Close codes from the gateway that mean "safe to resume/reconnect". */
 const RESUMABLE_CLOSE_CODES = new Set([4000, 4001, 4002, 4009, 1000, 1001, 1006]);
 
@@ -71,6 +78,8 @@ class DiscordGateway extends EventEmitter {
         this.user = null;
         /** @type {boolean} True once READY or RESUMED has been received. */
         this.ready = false;
+        /** @type {PresenceStatus|null} Last status we set, reconciled with the server. */
+        this.status = null;
 
         this._heartbeatIntervalMs = null;
         this._heartbeatTimer = null;
@@ -89,6 +98,30 @@ class DiscordGateway extends EventEmitter {
         this._closing = false;
         const url = this.gatewayUrl ?? await this.#fetchGatewayUrl();
         await this.#openSocket(url);
+    }
+
+    /**
+     * Update this account's presence status (opcode 4, Update Status).
+     * @param {PresenceStatus} status New status.
+     * @param {boolean} [afk] Whether to mark the account AFK. Mostly
+     *   cosmetic for user accounts.
+     * @returns {Promise<void>} Resolves once the frame has been sent.
+     * @throws {Error} If the status is invalid or the socket is not open.
+     */
+    setPresence(status, afk = false) {
+        if (!VALID_STATUSES.has(status)) {
+            return Promise.reject(new Error(`invalid status: ${status}`));
+        }
+        if (!this.ws || this.ws.readyState !== 1 /* OPEN */) {
+            return Promise.reject(new Error("gateway is not connected"));
+        }
+        this.status = status;
+        this.#send({
+            op: OPCODE.PRESENCE_UPDATE,
+            d: { status, afk, since: null, activities: [] },
+        });
+        this.emit("presence-set", status);
+        return Promise.resolve();
     }
 
     /**
@@ -231,9 +264,15 @@ class DiscordGateway extends EventEmitter {
             this.ready = true;
             this._reconnectDelayMs = this.reconnectBaseDelayMs;
             this.emit("ready", data.user);
+        } else if (type === "PRESENCE_UPDATE") {
+            // Reconcile our tracked status with the server's view. Other
+            // users' presence updates are ignored.
+            if (data?.user?.id === this.user?.id && data.status !== this.status) {
+                this.status = data.status;
+                this.emit("status", data.status);
+            }
         }
-        // Other dispatches (GUILD_CREATE, PRESENCE_UPDATE, ...) are ignored
-        // or handled in later steps.
+        // Other dispatches (GUILD_CREATE, ...) are ignored.
     }
 
     /**

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -1,0 +1,298 @@
+"use strict";
+
+/**
+ * Minimal Discord Gateway client for user accounts.
+ *
+ * Speaks the official Gateway protocol directly (the same protocol the
+ * Discord web client uses) instead of relying on a third-party selfbot
+ * library. Supports just what this app needs:
+ *
+ *  - connect / identify / heartbeat / READY
+ *  - presence updates (opcode 4) + status tracking
+ *  - session resume (opcode 6) with reconnect/backoff
+ *
+ * Uses Node's built-in global `WebSocket` (Node >= 22), so there are no
+ * runtime dependencies.
+ */
+
+const { EventEmitter } = require("node:events");
+
+const API_BASE = "https://discord.com/api/v10";
+const GATEWAY_VERSION = 10;
+
+/** Gateway opcode constants. @see https://discord.com/developers/docs/topics/gateway-list */
+const OPCODE = Object.freeze({
+    DISPATCH: 0,
+    HEARTBEAT: 1,
+    IDENTIFY: 2,
+    RESUME: 6,
+    RECONNECT: 7,
+    INVALID_SESSION: 9,
+    HELLO: 10,
+    HEARTBEAT_ACK: 11,
+    PRESENCE_UPDATE: 4,
+});
+
+/** Intents requested at IDENTIFY time: GUILDS (1) | GUILD_PRESENCES (8). */
+const INTENTS = (1 << 0) | (1 << 3);
+
+/** Close codes from the gateway that mean "safe to resume/reconnect". */
+const RESUMABLE_CLOSE_CODES = new Set([4000, 4001, 4002, 4009, 1000, 1001, 1006]);
+
+/**
+ * @typedef {Object} DiscordGatewayOptions
+ * @property {string} token Discord user token.
+ * @property {string} [gatewayUrl] Full ws:// URL. Skips the /gateway fetch
+ *   (mainly for tests).
+ * @property {typeof WebSocket} [WebSocketImpl] WebSocket constructor to use.
+ *   Defaults to the global one. Injected for tests.
+ * @property {number} [reconnectBaseDelayMs] Base delay for reconnect
+ *   backoff. Default 1000.
+ */
+
+class DiscordGateway extends EventEmitter {
+    /**
+     * @param {DiscordGatewayOptions} options
+     */
+    constructor({ token, gatewayUrl, WebSocketImpl, reconnectBaseDelayMs = 1000 }) {
+        super();
+        this.token = token;
+        this.gatewayUrl = gatewayUrl;
+        this.WebSocketImpl = WebSocketImpl ?? globalThis.WebSocket;
+        this.reconnectBaseDelayMs = reconnectBaseDelayMs;
+
+        /** @type {WebSocket|null} */
+        this.ws = null;
+        /** @type {string|null} Session id from READY, used for RESUME. */
+        this.sessionId = null;
+        /** @type {number|null} Last dispatch sequence number. */
+        this.seq = null;
+        /** @type {Object|null} Our user object from READY. */
+        this.user = null;
+        /** @type {boolean} True once READY or RESUMED has been received. */
+        this.ready = false;
+
+        this._heartbeatIntervalMs = null;
+        this._heartbeatTimer = null;
+        this._lastAckMs = 0;
+        this._reconnectDelayMs = reconnectBaseDelayMs;
+        this._closing = false;
+    }
+
+    /**
+     * Connect to the gateway and start a session.
+     * Resolves once IDENTIFY (or RESUME) has been sent; readiness is signalled
+     * by the `ready` / `resumed` events.
+     * @returns {Promise<void>}
+     */
+    async connect() {
+        this._closing = false;
+        const url = this.gatewayUrl ?? await this.#fetchGatewayUrl();
+        await this.#openSocket(url);
+    }
+
+    /**
+     * Close the connection without reconnecting.
+     * @returns {void}
+     */
+    disconnect() {
+        this._closing = true;
+        this.#stopHeartbeat();
+        const ws = this.ws;
+        this.ws = null;
+        this.ready = false;
+        if (ws) {
+            try { ws.close(1000); } catch { /* already closed */ }
+        }
+    }
+
+    /**
+     * Fetch the current gateway url from the official API.
+     * @returns {Promise<string>} ws:// URL with version + encoding query params.
+     */
+    async #fetchGatewayUrl() {
+        const res = await fetch(`${API_BASE}/gateway`);
+        if (!res.ok) {
+            throw new Error(`failed to fetch gateway url (http ${res.status})`);
+        }
+        const { url } = await res.json();
+        return `${url}?v=${GATEWAY_VERSION}&encoding=json`;
+    }
+
+    /**
+     * Open the WebSocket and attach protocol handlers.
+     * @param {string} url
+     * @returns {Promise<void>} Resolves once IDENTIFY/RESUME has been sent.
+     * @private
+     */
+    #openSocket(url) {
+        return new Promise((resolve, reject) => {
+            const ws = new this.WebSocketImpl(url);
+            this.ws = ws;
+            let sessionStarted = false;
+
+            ws.onopen = () => {
+                // Nothing to do until HELLO arrives; the protocol is
+                // server-initiated.
+            };
+            ws.onmessage = (event) => {
+                if (this.ws !== ws) return; // stale socket
+                this.#onMessage(event.data, () => {
+                    if (!sessionStarted) {
+                        sessionStarted = true;
+                        resolve();
+                    }
+                });
+            };
+            ws.onclose = (event) => {
+                if (this.ws !== ws) return; // stale socket
+                this.ws = null;
+                this.#onClose(event.code);
+                if (!sessionStarted) reject(new Error(`gateway closed before session started (code ${event.code})`));
+            };
+            ws.onerror = () => { /* onclose always follows; handled there */ };
+        });
+    }
+
+    /**
+     * Handle a raw gateway packet.
+     * @param {string} raw JSON text.
+     * @param {() => void} onSessionStarted Called once IDENTIFY/RESUME went out.
+     * @private
+     */
+    #onMessage(raw, onSessionStarted) {
+        /** @type {{op: number, s?: number, t?: string, d?: any}} */
+        let packet;
+        try {
+            packet = JSON.parse(raw);
+        } catch {
+            return;
+        }
+        if (typeof packet.s === "number") this.seq = packet.s;
+
+        switch (packet.op) {
+            case OPCODE.HELLO:
+                this.#onHello(packet.d, onSessionStarted);
+                break;
+            case OPCODE.HEARTBEAT:
+                // Server-requested immediate heartbeat.
+                this.#sendHeartbeat();
+                break;
+            case OPCODE.HEARTBEAT_ACK:
+                this._lastAckMs = Date.now();
+                break;
+            case OPCODE.DISPATCH:
+                this.#onDispatch(packet.t, packet.d);
+                break;
+            default:
+                // Opcodes added by Discord in the future are ignored.
+                break;
+        }
+    }
+
+    /**
+     * Start the heartbeat loop and send IDENTIFY (or RESUME later).
+     * @param {{heartbeat_interval: number}} hello
+     * @param {() => void} onSessionStarted
+     * @private
+     */
+    #onHello({ heartbeat_interval }, onSessionStarted) {
+        this._heartbeatIntervalMs = heartbeat_interval;
+        this._lastAckMs = Date.now();
+        this.#startHeartbeat();
+
+        this.#send({
+            op: OPCODE.IDENTIFY,
+            d: {
+                token: this.token,
+                intents: INTENTS,
+                properties: {
+                    os: "linux",
+                    browser: "discord-status-spoofer",
+                    device: "discord-status-spoofer",
+                },
+                compress: false,
+                presence: { status: "online", afk: false },
+            },
+        });
+        onSessionStarted();
+    }
+
+    /**
+     * Handle a dispatch event (opcode 0).
+     * @param {string} type Event name (READY, PRESENCE_UPDATE, ...).
+     * @param {any} data Event payload.
+     * @private
+     */
+    #onDispatch(type, data) {
+        if (type === "READY") {
+            this.sessionId = data.session_id;
+            this.user = data.user;
+            this.ready = true;
+            this._reconnectDelayMs = this.reconnectBaseDelayMs;
+            this.emit("ready", data.user);
+        }
+        // Other dispatches (GUILD_CREATE, PRESENCE_UPDATE, ...) are ignored
+        // or handled in later steps.
+    }
+
+    /**
+     * Handle the socket closing.
+     * @param {number} code Close code.
+     * @private
+     */
+    #onClose(code) {
+        this.#stopHeartbeat();
+        this.ready = false;
+        this.emit("close", code);
+    }
+
+    /**
+     * Start the heartbeat timer (first beat goes out immediately, per spec).
+     * @private
+     */
+    #startHeartbeat() {
+        this.#stopHeartbeat();
+        this.#sendHeartbeat();
+        this._heartbeatTimer = setInterval(() => {
+            this.#sendHeartbeat();
+            // Zombie connection detection: no ACK within 2 intervals.
+            if (Date.now() - this._lastAckMs > 2 * this._heartbeatIntervalMs) {
+                this.emit("close", "zombie-connection");
+            }
+        }, this._heartbeatIntervalMs);
+        this._heartbeatTimer.unref?.();
+    }
+
+    /**
+     * Stop the heartbeat timer.
+     * @private
+     */
+    #stopHeartbeat() {
+        if (this._heartbeatTimer) {
+            clearInterval(this._heartbeatTimer);
+            this._heartbeatTimer = null;
+        }
+    }
+
+    /**
+     * Send a heartbeat (opcode 1) with the last seq (or null).
+     * @private
+     */
+    #sendHeartbeat() {
+        this.#send({ op: OPCODE.HEARTBEAT, d: this.seq });
+    }
+
+    /**
+     * Send a JSON frame if the socket is open.
+     * @param {Object} payload
+     * @private
+     */
+    #send(payload) {
+        if (this.ws && this.ws.readyState === 1 /* OPEN */) {
+            this.ws.send(JSON.stringify(payload));
+        }
+    }
+}
+
+module.exports = { DiscordGateway, OPCODE };

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -43,8 +43,8 @@ const VALID_STATUSES = new Set(["online", "idle", "dnd", "invisible"]);
  * @typedef {"online"|"idle"|"dnd"|"invisible"} PresenceStatus
  */
 
-/** Close codes from the gateway that mean "safe to resume/reconnect". */
-const RESUMABLE_CLOSE_CODES = new Set([4000, 4001, 4002, 4009, 1000, 1001, 1006]);
+/** Close codes meaning the current session can no longer be resumed. */
+const NON_RESUMABLE_CLOSE_CODES = new Set([4007, 4008]); // invalid seq / already resumed
 
 /**
  * @typedef {Object} DiscordGatewayOptions
@@ -85,7 +85,11 @@ class DiscordGateway extends EventEmitter {
         this._heartbeatTimer = null;
         this._lastAckMs = 0;
         this._reconnectDelayMs = reconnectBaseDelayMs;
+        this._reconnectTimer = null;
+        this._resumeTimer = null;
         this._closing = false;
+        /** True once IDENTIFY/RESUME has been sent (connect() resolved). */
+        this._connected = false;
     }
 
     /**
@@ -131,6 +135,11 @@ class DiscordGateway extends EventEmitter {
     disconnect() {
         this._closing = true;
         this.#stopHeartbeat();
+        this.#clearResumeTimer();
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
         const ws = this.ws;
         this.ws = null;
         this.ready = false;
@@ -173,6 +182,7 @@ class DiscordGateway extends EventEmitter {
                 this.#onMessage(event.data, () => {
                     if (!sessionStarted) {
                         sessionStarted = true;
+                        this._connected = true;
                         resolve();
                     }
                 });
@@ -214,6 +224,13 @@ class DiscordGateway extends EventEmitter {
             case OPCODE.HEARTBEAT_ACK:
                 this._lastAckMs = Date.now();
                 break;
+            case OPCODE.RECONNECT:
+                this.#reconnect("gateway requested reconnect (op 7)");
+                break;
+            case OPCODE.INVALID_SESSION:
+                if (!packet.d) this.sessionId = null;
+                this.#reconnect("invalid session (op 9)");
+                break;
             case OPCODE.DISPATCH:
                 this.#onDispatch(packet.t, packet.d);
                 break;
@@ -234,20 +251,30 @@ class DiscordGateway extends EventEmitter {
         this._lastAckMs = Date.now();
         this.#startHeartbeat();
 
-        this.#send({
-            op: OPCODE.IDENTIFY,
-            d: {
-                token: this.token,
-                intents: INTENTS,
-                properties: {
-                    os: "linux",
-                    browser: "discord-status-spoofer",
-                    device: "discord-status-spoofer",
+        if (this.sessionId) {
+            // Existing session: try to resume it (the server keeps our
+            // presence state across a resume).
+            this.#send({
+                op: OPCODE.RESUME,
+                d: { token: this.token, session_id: this.sessionId, seq: this.seq },
+            });
+            this.#startResumeTimer();
+        } else {
+            this.#send({
+                op: OPCODE.IDENTIFY,
+                d: {
+                    token: this.token,
+                    intents: INTENTS,
+                    properties: {
+                        os: "linux",
+                        browser: "discord-status-spoofer",
+                        device: "discord-status-spoofer",
+                    },
+                    compress: false,
+                    presence: { status: "online", afk: false },
                 },
-                compress: false,
-                presence: { status: "online", afk: false },
-            },
-        });
+            });
+        }
         onSessionStarted();
     }
 
@@ -263,7 +290,13 @@ class DiscordGateway extends EventEmitter {
             this.user = data.user;
             this.ready = true;
             this._reconnectDelayMs = this.reconnectBaseDelayMs;
+            this.#clearResumeTimer();
             this.emit("ready", data.user);
+        } else if (type === "RESUMED") {
+            this.ready = true;
+            this._reconnectDelayMs = this.reconnectBaseDelayMs;
+            this.#clearResumeTimer();
+            this.emit("resumed");
         } else if (type === "PRESENCE_UPDATE") {
             // Reconcile our tracked status with the server's view. Other
             // users' presence updates are ignored.
@@ -282,8 +315,78 @@ class DiscordGateway extends EventEmitter {
      */
     #onClose(code) {
         this.#stopHeartbeat();
+        this.#clearResumeTimer();
         this.ready = false;
+        if (this._closing) return;
+        if (code === 4004) {
+            // Authentication failed — retrying will not help.
+            this.emit("fatal", new Error(
+                "gateway authentication failed (close code 4004) — check your token"
+            ));
+            return;
+        }
         this.emit("close", code);
+        if (typeof code === "number" && NON_RESUMABLE_CLOSE_CODES.has(code)) {
+            this.sessionId = null; // force a fresh IDENTIFY
+        }
+        // If connect() has not resolved yet, it will reject and the caller
+        // owns the retry. Once resolved, this class owns reconnection.
+        if (this._connected) {
+            this.#reconnect(`socket closed with code ${code}`);
+        }
+    }
+
+    /**
+     * Schedule a reconnect with exponential backoff (base → 30s cap).
+     * If a session id exists, the next connect will attempt RESUME.
+     * @param {string} reason Human-readable trigger, for logging.
+     * @private
+     */
+    #reconnect(reason) {
+        if (this._closing || this._reconnectTimer) return;
+        this.emit("reconnecting", { reason, delayMs: this._reconnectDelayMs });
+        const delay = this._reconnectDelayMs;
+        this._reconnectDelayMs = Math.min(this._reconnectDelayMs * 2, 30_000);
+        const ws = this.ws;
+        this.ws = null;
+        if (ws) {
+            try { ws.close(4000); } catch { /* already closed */ }
+        }
+        // Intentionally NOT unref()'d: while reconnecting the socket is
+        // gone, so this timer must keep the process alive.
+        this._reconnectTimer = setTimeout(() => {
+            this._reconnectTimer = null;
+            this.connect().catch((err) => {
+                this.emit("error", err);
+                this.#reconnect(`connect failed: ${err.message}`);
+            });
+        }, delay);
+    }
+
+    /**
+     * Give up on resuming if RESUMED does not arrive within 30s.
+     * @private
+     */
+    #startResumeTimer() {
+        this.#clearResumeTimer();
+        this._resumeTimer = setTimeout(() => {
+            this._resumeTimer = null;
+            this.sessionId = null;
+            this.seq = null;
+            this.#reconnect("session was not resumed in time");
+        }, 30_000);
+        this._resumeTimer.unref?.();
+    }
+
+    /**
+     * Clear the resume timer if set.
+     * @private
+     */
+    #clearResumeTimer() {
+        if (this._resumeTimer) {
+            clearTimeout(this._resumeTimer);
+            this._resumeTimer = null;
+        }
     }
 
     /**
@@ -297,7 +400,7 @@ class DiscordGateway extends EventEmitter {
             this.#sendHeartbeat();
             // Zombie connection detection: no ACK within 2 intervals.
             if (Date.now() - this._lastAckMs > 2 * this._heartbeatIntervalMs) {
-                this.emit("close", "zombie-connection");
+                this.#reconnect("no heartbeat ack (zombie connection)");
             }
         }, this._heartbeatIntervalMs);
         this._heartbeatTimer.unref?.();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,148 +4,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "discord-status-spoofer",
       "dependencies": {
-        "cors": "^2.8.5",
-        "discord.js-selfbot-v13": "^3.6.1",
         "dotenv": "^17.0.1",
-        "express": "^5.1.0",
-        "path": "^0.12.7"
+        "express": "^5.1.0"
       }
-    },
-    "node_modules/@discordjs/builders": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
-      "integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.1",
-        "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.4",
-        "tslib": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/builders/node_modules/@sapphire/shapeshift": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v16"
-      }
-    },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.38.15",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.15.tgz",
-      "integrity": "sha512-RX3skyRH7p6BlHOW62ztdnIc87+wv4TEJEURMir5k5BbRJ10wK1MCqFEO6USHTol3gkiHLE6wWoHhNQ2pqB4AA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
-    "node_modules/@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@discordjs/formatters": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
-      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "discord-api-types": "^0.38.1"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.38.15",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.15.tgz",
-      "integrity": "sha512-RX3skyRH7p6BlHOW62ztdnIc87+wv4TEJEURMir5k5BbRJ10wK1MCqFEO6USHTol3gkiHLE6wWoHhNQ2pqB4AA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
-    "node_modules/@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@minhducsun2002/leb128": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
-      "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
-      "license": "MIT"
-    },
-    "node_modules/@sapphire/async-queue": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
-      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.7.tgz",
-      "integrity": "sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v16"
-      }
-    },
-    "node_modules/@shinyoshiaki/binary-data": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
-      "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
-      "license": "MIT",
-      "dependencies": {
-        "generate-function": "^2.3.1",
-        "is-plain-object": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@shinyoshiaki/jspack": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
-      "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -160,98 +23,41 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/aes-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -290,69 +96,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -394,23 +137,10 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -424,15 +154,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -440,43 +161,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dijkstrajs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
-      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-      "license": "MIT"
-    },
-    "node_modules/discord-api-types": {
-      "version": "0.37.120",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
-      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
-      "license": "MIT"
-    },
-    "node_modules/discord.js-selfbot-v13": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/discord.js-selfbot-v13/-/discord.js-selfbot-v13-3.6.1.tgz",
-      "integrity": "sha512-0RVv3u2sJZaGUKYPsUDtl4Zdbas5XuNGuR6409Qdm0/LLIcVm+677OydcCMDu9njwstwYMNWhl/8Zqpm5OrtnQ==",
-      "license": "GNU General Public License v3.0",
-      "dependencies": {
-        "@discordjs/builders": "^1.6.3",
-        "@discordjs/collection": "^1.5.3",
-        "@sapphire/async-queue": "^1.5.5",
-        "@sapphire/shapeshift": "^3.9.5",
-        "discord-api-types": "^0.37.117",
-        "fetch-cookie": "^2.1.0",
-        "find-process": "^1.4.10",
-        "prism-media": "^1.3.5",
-        "qrcode": "^1.5.4",
-        "tough-cookie": "^4.1.4",
-        "tree-kill": "^1.2.2",
-        "undici": "^6.21.0",
-        "werift-rtp": "^0.8.4",
-        "ws": "^8.16.0"
-      },
-      "engines": {
-        "node": ">=20.18"
       }
     },
     "node_modules/dotenv": {
@@ -511,12 +195,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -545,9 +223,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -613,22 +291,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fetch-cookie": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
-      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
-      "license": "Unlicense",
-      "dependencies": {
-        "set-cookie-parser": "^2.4.8",
-        "tough-cookie": "^4.0.0"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -644,33 +306,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/find-process": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
-      "integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "~4.1.2",
-        "commander": "^12.1.0",
-        "loglevel": "^1.9.2"
-      },
-      "bin": {
-        "find-process": "bin/find-process.js"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/forwarded": {
@@ -698,24 +333,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -767,15 +384,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -789,9 +397,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -801,61 +409,40 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -872,78 +459,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "license": "MIT"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/loglevel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -996,12 +516,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mp4box": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
-      "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1015,15 +529,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1059,42 +564,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1104,76 +573,14 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/prism-media": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
-      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@discordjs/opus": ">=0.8.0 <1.0.0",
-        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {
@@ -1189,51 +596,14 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
-      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "dijkstrajs": "^1.0.1",
-        "pngjs": "^5.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1241,12 +611,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -1258,40 +622,19 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "license": "ISC"
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -1308,11 +651,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/rx.mini": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
-      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1377,18 +715,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -1396,14 +722,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1415,13 +741,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1476,44 +802,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1523,72 +811,35 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {
@@ -1600,31 +851,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1634,112 +860,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/werift-rtp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/werift-rtp/-/werift-rtp-0.8.4.tgz",
-      "integrity": "sha512-n2FqQoSZnrS6ztMFkMMUee0ORh4JqdkEaaXwJ3NlemCoshcX3bfdKo4HukLwH2oBomfHFRIAvrqGRpo5JdYTzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@minhducsun2002/leb128": "^1.0.0",
-        "@shinyoshiaki/binary-data": "^0.6.1",
-        "@shinyoshiaki/jspack": "^0.0.6",
-        "aes-js": "^3.1.2",
-        "buffer": "^6.0.3",
-        "debug": "^4.3.4",
-        "mp4box": "^0.5.2",
-        "rx.mini": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "license": "ISC"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "discord.js-selfbot-v13": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "cors": "^2.8.5",
-    "discord.js-selfbot-v13": "^3.6.1",
     "dotenv": "^17.0.1",
-    "express": "^5.1.0",
-    "path": "^0.12.7"
+    "express": "^5.1.0"
   }
 }

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -1,0 +1,269 @@
+"use strict";
+
+/**
+ * Protocol tests for the native Discord gateway client.
+ *
+ * Runs against a mock WebSocket that speaks just enough of the gateway
+ * protocol (HELLO → IDENTIFY/RESUME → dispatches → acks), so no network
+ * access or real token is needed:  node --test
+ */
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { DiscordGateway } = require("../lib/discord-gateway");
+
+/**
+ * Mock WebSocket speaking a subset of the Discord gateway protocol.
+ * Mirrors the browser-style API surface used by DiscordGateway
+ * (onopen/onmessage/onclose/onerror/send/close/readyState).
+ */
+class MockWebSocket {
+    /** Every constructed socket, in order. */
+    static instances = [];
+    /** User object delivered in READY. */
+    static USER = { id: "u-1", username: "tester" };
+    /** When true, the socket closes (1006) before sending HELLO. */
+    static failFast = false;
+
+    /** @param {string} url */
+    constructor(url) {
+        this.url = url;
+        this.readyState = 0; // CONNECTING
+        /** @type {Array<Object>} Frames sent by the client, parsed. */
+        this.sent = [];
+        this.onopen = null;
+        this.onmessage = null;
+        this.onclose = null;
+        this.onerror = null;
+        MockWebSocket.instances.push(this);
+        setImmediate(() => {
+            if (MockWebSocket.failFast) {
+                this.close(1006);
+                return;
+            }
+            this.readyState = 1; // OPEN
+            this.onopen?.();
+            this.push({ op: 10, d: { heartbeat_interval: 50 } });
+        });
+    }
+
+    /**
+     * Deliver a raw gateway packet to the client.
+     * @param {Object} packet
+     */
+    push(packet) {
+        setImmediate(() => this.onmessage?.({ data: JSON.stringify(packet) }));
+    }
+
+    /**
+     * Handle a frame from the client and reply like the gateway would.
+     * @param {string} data JSON frame.
+     */
+    send(data) {
+        const frame = JSON.parse(data);
+        this.sent.push(frame);
+        switch (frame.op) {
+            case 2: // IDENTIFY
+                this.push({ op: 0, s: 1, t: "READY", d: { session_id: "session-1", user: MockWebSocket.USER } });
+                break;
+            case 6: // RESUME
+                this.push({ op: 0, s: 2, t: "RESUMED", d: {} });
+                break;
+            case 1: // HEARTBEAT
+                this.push({ op: 11, d: null });
+                break;
+            case 4: // PRESENCE_UPDATE — echo the server's view
+                this.push({
+                    op: 0, s: 3, t: "PRESENCE_UPDATE",
+                    d: { user: { id: MockWebSocket.USER.id }, status: frame.d.status },
+                });
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Close the socket.
+     * @param {number} [code] Close code delivered to onclose.
+     */
+    close(code = 1006) {
+        if (this.readyState === 3) return;
+        this.readyState = 3; // CLOSED
+        setImmediate(() => this.onclose?.({ code }));
+    }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Wait for an event on an EventEmitter, with a timeout.
+ * @template T
+ * @param {import("node:events").EventEmitter} emitter
+ * @param {string} event
+ * @param {number} [timeoutMs]
+ * @returns {Promise<T[]>} Event arguments.
+ */
+function waitFor(emitter, event, timeoutMs = 2000) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error(`timed out waiting for "${event}"`)),
+            timeoutMs,
+        );
+        emitter.once(event, (...args) => {
+            clearTimeout(timer);
+            resolve(args);
+        });
+    });
+}
+
+/**
+ * Create a gateway wired to the mock and wait until READY.
+ * @param {Object} [options] Extra DiscordGateway options.
+ * @returns {Promise<DiscordGateway>}
+ */
+async function connectReady(options = {}) {
+    const gateway = new DiscordGateway({
+        token: "token-123",
+        WebSocketImpl: MockWebSocket,
+        gatewayUrl: "ws://mock/gateway",
+        reconnectBaseDelayMs: 20,
+        ...options,
+    });
+    const readyPromise = waitFor(gateway, "ready");
+    gateway.connect().catch(() => { /* asserted per-test */ });
+    await readyPromise;
+    return gateway;
+}
+
+test("identifies with token + intents and emits ready", async () => {
+    const gateway = await connectReady();
+    const socket = MockWebSocket.instances.at(-1);
+    const identify = socket.sent.find((f) => f.op === 2);
+
+    assert.equal(identify.d.token, "token-123");
+    assert.equal(identify.d.intents, (1 << 0) | (1 << 3)); // GUILDS | GUILD_PRESENCES
+    assert.equal(identify.d.presence.status, "online");
+    assert.equal(gateway.sessionId, "session-1");
+    assert.equal(gateway.user.id, "u-1");
+    assert.equal(gateway.ready, true);
+    gateway.disconnect();
+});
+
+test("setPresence rejects before the socket is open", async () => {
+    const gateway = new DiscordGateway({
+        token: "token-123",
+        WebSocketImpl: MockWebSocket,
+        gatewayUrl: "ws://mock/gateway",
+    });
+    await assert.rejects(gateway.setPresence("idle"), /not connected/);
+    await assert.rejects(gateway.setPresence("bogus"), /invalid status/);
+});
+
+test("setPresence sends op 4 and tracks the status", async () => {
+    const gateway = await connectReady();
+    const socket = MockWebSocket.instances.at(-1);
+
+    await gateway.setPresence("dnd", false);
+
+    const frame = socket.sent.at(-1);
+    assert.deepEqual(frame, {
+        op: 4,
+        d: { status: "dnd", afk: false, since: null, activities: [] },
+    });
+    assert.equal(gateway.status, "dnd");
+    gateway.disconnect();
+});
+
+test("server PRESENCE_UPDATE reconciles the tracked status", async () => {
+    const gateway = await connectReady();
+    const socket = MockWebSocket.instances.at(-1);
+
+    const statusChange = waitFor(gateway, "status");
+    // Simulate the account's status changing from another client.
+    socket.push({
+        op: 0, s: 4, t: "PRESENCE_UPDATE",
+        d: { user: { id: MockWebSocket.USER.id }, status: "idle" },
+    });
+
+    assert.deepEqual(await statusChange, ["idle"]);
+    assert.equal(gateway.status, "idle");
+    gateway.disconnect();
+});
+
+test("sends heartbeats on the hello interval, carrying the last seq", async () => {
+    const gateway = await connectReady(); // mock heartbeat_interval = 50ms
+    const socket = MockWebSocket.instances.at(-1);
+
+    await sleep(180);
+
+    const beats = socket.sent.filter((f) => f.op === 1);
+    assert.ok(beats.length >= 2, `expected >= 2 heartbeats, got ${beats.length}`);
+    assert.equal(beats[0].d, null); // first beat before any dispatch
+    assert.ok(beats.some((f) => f.d === 1), "later beats carry the last seq");
+    gateway.disconnect();
+});
+
+test("resumes the session after a reconnect (no re-identify)", async () => {
+    const gateway = await connectReady();
+    await gateway.setPresence("idle", false);
+    const firstSocket = MockWebSocket.instances.at(-1);
+
+    firstSocket.close(4009); // gateway-side "reconnect" close
+
+    const resumed = waitFor(gateway, "resumed");
+    await resumed;
+
+    const secondSocket = MockWebSocket.instances.at(-1);
+    assert.notEqual(secondSocket, firstSocket);
+    const resume = secondSocket.sent.find((f) => f.op === 6);
+    assert.ok(resume, "expected a RESUME frame");
+    assert.equal(resume.d.token, "token-123");
+    assert.equal(resume.d.session_id, "session-1");
+    // READY is s:1; the mock's PRESENCE_UPDATE echo for the op-4 frame is s:3.
+    assert.equal(resume.d.seq, 3);
+    assert.ok(!secondSocket.sent.some((f) => f.op === 2), "must not re-IDENTIFY");
+    assert.equal(gateway.status, "idle"); // presence survived the resume
+    assert.equal(gateway.ready, true);
+    gateway.disconnect();
+});
+
+test("emits fatal on auth failure (close 4004) and does not reconnect", async () => {
+    const gateway = await connectReady();
+    const socket = MockWebSocket.instances.at(-1);
+    const instanceCount = MockWebSocket.instances.length;
+
+    const fatal = waitFor(gateway, "fatal");
+    socket.close(4004);
+    const [error] = await fatal;
+    assert.match(error.message, /4004/);
+    assert.equal(gateway.ready, false);
+
+    await sleep(100); // a reconnect (if any) would happen at 20ms
+    assert.equal(MockWebSocket.instances.length, instanceCount, "no new socket after fatal");
+});
+
+test("rejects connect() when the socket dies before the session starts", async () => {
+    MockWebSocket.failFast = true;
+    try {
+        const gateway = new DiscordGateway({
+            token: "token-123",
+            WebSocketImpl: MockWebSocket,
+            gatewayUrl: "ws://mock/gateway",
+        });
+        await assert.rejects(gateway.connect(), /before session started/);
+    } finally {
+        MockWebSocket.failFast = false;
+    }
+});
+
+test("disconnect() prevents reconnection", async () => {
+    const gateway = await connectReady();
+    const instanceCount = MockWebSocket.instances.length;
+
+    gateway.disconnect();
+    await sleep(100);
+    assert.equal(gateway.ready, false);
+    assert.equal(MockWebSocket.instances.length, instanceCount, "no new socket after disconnect");
+});

--- a/test/http-surface.test.js
+++ b/test/http-surface.test.js
@@ -1,0 +1,132 @@
+"use strict";
+
+/**
+ * Integration test for the Express API surface of index.js, with the
+ * gateway module stubbed out (no network, no token needed).
+ *
+ * Run with:  node --test
+ */
+
+const { test, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+
+const PORT = 4317;
+
+/**
+ * Stand-in for DiscordGateway with the same surface index.js uses.
+ */
+class StubGateway extends EventEmitter {
+    /** @type {StubGateway|null} Most recently constructed instance. */
+    static instance = null;
+
+    /** @param {{token: string}} options */
+    constructor(options) {
+        super();
+        StubGateway.instance = this;
+        this.token = options.token;
+        this.ready = false;
+        this.status = null;
+        /** @type {Array<[string, boolean]>} setPresence calls in order. */
+        this.presenceCalls = [];
+    }
+
+    /** @returns {Promise<void>} */
+    connect() { return Promise.resolve(); }
+
+    /** @returns {void} */
+    disconnect() { /* no-op */ }
+
+    /**
+     * @param {string} status
+     * @param {boolean} [afk]
+     * @returns {Promise<void>}
+     */
+    async setPresence(status, afk = false) {
+        if (!this.ready) throw new Error("gateway is not connected");
+        this.presenceCalls.push([status, afk]);
+        this.status = status;
+    }
+
+    /** Test helper: pretend the gateway became ready. */
+    becomeReady() {
+        this.ready = true;
+        this.emit("ready", { username: "stub" });
+    }
+}
+
+// Inject the stub into the require cache BEFORE index.js loads the real
+// gateway module.
+const gatewayPath = path.join(__dirname, "..", "lib", "discord-gateway.js");
+const resolved = require.resolve(gatewayPath);
+require.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    exports: { DiscordGateway: StubGateway, OPCODE: {} },
+};
+
+process.env.PORT = String(PORT);
+process.env.TOKEN = "stub-token";
+require("../index.js");
+
+const base = `http://127.0.0.1:${PORT}`;
+
+/**
+ * Wait until the express server accepts connections.
+ * @returns {Promise<void>}
+ */
+async function waitServer() {
+    for (let i = 0; i < 50; i++) {
+        try {
+            await fetch(`${base}/api/getStatus`);
+            return;
+        } catch {
+            await new Promise((r) => setTimeout(r, 100));
+        }
+    }
+    throw new Error("express server did not start");
+}
+
+test("getStatus returns 500 before the gateway is ready", async () => {
+    await waitServer();
+    const res = await fetch(`${base}/api/getStatus`);
+    assert.equal(res.status, 500);
+});
+
+test("updateStatus returns 500 before the gateway is ready", async () => {
+    const res = await fetch(`${base}/api/updateStatus`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newStatus: "idle" }),
+    });
+    assert.equal(res.status, 500);
+});
+
+test("after ready: default status is online and updateStatus changes it", async () => {
+    StubGateway.instance.becomeReady();
+    // Let the ready handler's changeStatus('online') microtask settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    let res = await fetch(`${base}/api/getStatus`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { currentStatus: "online" });
+
+    res = await fetch(`${base}/api/updateStatus`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newStatus: "dnd" }),
+    });
+    assert.equal(res.status, 200);
+
+    res = await fetch(`${base}/api/getStatus`);
+    assert.deepEqual(await res.json(), { currentStatus: "dnd" });
+    assert.deepEqual(StubGateway.instance.presenceCalls.at(-1), ["dnd", true]);
+});
+
+// index.js owns the express server for the whole process; end the test
+// process explicitly, preserving any failure exit code.
+after(() => {
+    process.exit(process.exitCode ?? 0);
+});


### PR DESCRIPTION
## Why
`discord.js-selfbot-v13` is old and unmaintained. This removes it by speaking the
official Discord Gateway protocol directly with Node's built-in `WebSocket`
(Node >= 22, image is Node 24) — zero new runtime dependencies.

Discord has no REST endpoint for presence; status can only be set via Gateway
opcode 4. That's exactly what the official web client does, so this mirrors it.

## What changed
- **`lib/discord-gateway.js`** (new): small `DiscordGateway` class —
  connect/identify/heartbeat, presence updates (op 4) + status tracking,
  session resume (op 6) with reconnect backoff, zombie-connection detection,
  and a `fatal` event on auth failure (close 4004).
- **`index.js`**: rewired to the new client. Same Express API surface and
  behavior (`getStatus`/`updateStatus`, default `online` on ready, restore
  last status or `invisible` on resume). Bad token now logs + `exit(1)` so the
  container restarts cleanly.
- **`package.json`**: dropped `discord.js-selfbot-v13`, plus unused `cors` and
  the bogus `path` "dependency"; `npm audit fix` for express transitive deps.
- **`test/`** (new): `node --test` suites — gateway protocol tests against a
  mock WebSocket, and an API-surface integration test with a stubbed gateway.
  No token or network needed.
- **`README.md`** / **`docs/plan-native-gateway.md`**: updated docs + plan.

## Behavior notes / caveats
- A personal token over the Gateway is still a self-bot per Discord ToS (see
  README) — this only removes the old library, it does not make it ToS-clean.
- Intents are `GUILDS | GUILD_PRESENCES`; only what's needed to set presence.

## Testing
- `npm test` → 11/11 pass (protocol + HTTP surface, no token/network).
- Live smoke test against the real gateway with an invalid token: connects,
  IDENTIFY accepted, Discord returns close 4004 → clean fatal log + exit(1).
- Docker build path unchanged (`CMD node index.js`).

Full plan: `docs/plan-native-gateway.md`.