### PR TITLE
fix: presence updates on op 3 (Presence Update), not op 4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# --- Secrets: must never enter the image. The token is provided at
+# --- runtime via `env_file` in docker-compose.yml (or `--env-file .env` /
+# --- `-e TOKEN` with plain docker run).
+.env
+.env.*
+*.pem
+*.key
+
+# --- VCS / editor clutter
+.git/
+.gitignore
+.DS_Store
+.vscode/
+
+# --- Host dependencies; `RUN npm install` in the Dockerfile rebuilds
+# --- these from package-lock.json.
+node_modules/
+
+# --- Dev-only; not needed by the running app.
+# --- (scripts/ is intentionally kept: it holds the diag-4002 tool, which
+# --- is run from inside the image with the token passed at runtime.)
+docs/
+test/
+readme_resources/
+env_template.txt
+Dockerfile
+docker-compose*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,10 @@ COPY . .
 
 RUN npm install
 
+# Run as the unprivileged user that ships with the official node image
+# (uid=1000, gid=1000) instead of root. The app only reads its own files
+# and listens on a port > 1024, so no root privileges are needed.
+USER node
+
 #start the app
 CMD ["node", "index.js"]

--- a/discord-spoofer-frontend/styles.css
+++ b/discord-spoofer-frontend/styles.css
@@ -140,28 +140,40 @@ body {
   transition: background 120ms ease;
 }
 
-/* Tint the avatar dot + status text to match the active status. */
-body[data-status="online"] .avatar__status,
-body[data-status="online"] .status-value {
+/* Tint the avatar dot + status text to match the active status.
+   The dot takes the status color as its background; the label keeps a
+   transparent background and only takes the status color as its text
+   color (painting the label's background too made it read as a solid
+   block of color with the text hidden inside it). */
+body[data-status="online"] .avatar__status {
   background: var(--status-online);
+}
+
+body[data-status="online"] .status-value {
   color: var(--status-online);
 }
 
-body[data-status="idle"] .avatar__status,
-body[data-status="idle"] .status-value {
+body[data-status="idle"] .avatar__status {
   background: var(--status-idle);
+}
+
+body[data-status="idle"] .status-value {
   color: var(--status-idle);
 }
 
-body[data-status="dnd"] .avatar__status,
-body[data-status="dnd"] .status-value {
+body[data-status="dnd"] .avatar__status {
   background: var(--status-dnd);
+}
+
+body[data-status="dnd"] .status-value {
   color: var(--status-dnd);
 }
 
-body[data-status="invisible"] .avatar__status,
-body[data-status="invisible"] .status-value {
+body[data-status="invisible"] .avatar__status {
   background: var(--status-invisible);
+}
+
+body[data-status="invisible"] .status-value {
   color: var(--status-invisible);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     container_name : discord-status-spoofer
     build: ./
     restart: unless-stopped
+    # Token (and PORT) are injected at runtime from the .env that lives
+    # next to this compose file — never baked into the image (see
+    # .dockerignore).
+    env_file:
+      - .env
     ports:
       - '${PORT:-8081}:${PORT:-8081}'
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     # .dockerignore).
     env_file:
       - .env
+    # Runtime user (uid:gid). Defaults to the image's unprivileged `node`
+    # user (1000:1000, see Dockerfile). Override by setting APP_UID /
+    # APP_GID in .env (or editing the defaults here). Plain numeric uids
+    # are fine even without a matching /etc/passwd entry in the image.
+    user: "${APP_UID:-1000}:${APP_GID:-1000}"
     ports:
       - '${PORT:-8081}:${PORT:-8081}'
     deploy:

--- a/docs/plan-native-gateway.md
+++ b/docs/plan-native-gateway.md
@@ -8,7 +8,11 @@ runs Node 24, which has a built-in global `WebSocket`.
 
 ## Background / constraints
 - Discord has **no REST endpoint for presence**. Status can only be changed via
-  Gateway opcode 4 (`Update Status`). Confirmed against the official API docs.
+  Gateway opcode 3 (`Presence Update`). Confirmed against the official API docs.
+  Caution: opcode 4 is `Voice State Update` (join/move/leave voice channels),
+  *not* a presence opcode — the original draft of this plan misread it as
+  "Update Status", and sending a presence payload on op 4 dies with
+  4002 "Error while decoding payload" (see `scripts/diag-4002.js`).
 - The app currently uses only 3 things from the library (all in `index.js`):
   1. `client.user.presence.status` → read current status
   2. `client.user.setPresence({ status, afk })` → change status
@@ -30,8 +34,10 @@ A small `DiscordGateway` class extending `EventEmitter`:
 - Heartbeat: op 1 every `heartbeat_interval`, last `seq` (null before any
   dispatch). Handle server-requested heartbeats (op 1) immediately. If no
   `HEARTBEAT ACK` (op 11) arrives within 2× the interval, force a reconnect.
-- `setPresence(status, afk)` → send op 4
-  `{"status": <s>, "afk": <a>, "since": null, "activities": []}`.
+- `setPresence(status, afk)` → send op 3
+  `{"status": <s>, "afk": <a>, "since": null | <now>, "activities": []}`
+  (`since` is `null` while online, a timestamp of when the status started
+  otherwise).
   Rejects if not connected. Resolves once the frame is sent.
 - Status tracking: `this.status` is set optimistically by `setPresence` and
   reconciled from `PRESENCE_UPDATE` dispatches for our own user id.

--- a/env_template.txt
+++ b/env_template.txt
@@ -1,2 +1,4 @@
 TOKEN='your-token'
-PORT=80
+# must be > 1024: the container runs as an unprivileged user
+# (default uid 1000; override with APP_UID/APP_GID in this file)
+PORT=8081

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ app.get('/api/getStatus', async (req, res) => {
 });
 
 // update the status {newStatus: "status", isAfk: bool}
-// isAfk maps to the afk field of the op 4 presence frame. It is a leftover
+// isAfk maps to the afk field of the op 3 presence frame. It is a leftover
 // from the python version and is always false now (matches the official
 // client); the UI's isAfk flag is accepted but intentionally ignored.
 app.post('/api/updateStatus', async (req, res) => {
@@ -76,7 +76,7 @@ app.post('/api/updateStatus', async (req, res) => {
 /**
  * change status
  * @param {string} newStatus 'online', 'idle', 'dnd', 'invisible'
- * @param {boolean} [isAfk] the afk field of the op 4 frame; keep false,
+ * @param {boolean} [isAfk] the afk field of the op 3 frame; keep false,
  *   matching the official client (afk:true is a leftover that does nothing
  *   useful for this app)
  */

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -8,7 +8,7 @@
  * library. Supports just what this app needs:
  *
  *  - connect / identify / heartbeat / READY
- *  - presence updates (opcode 4) + status tracking
+ *  - presence updates (opcode 3) + status tracking
  *  - session resume (opcode 6) with reconnect/backoff
  *
  * Uses Node's built-in global `WebSocket` (Node >= 22), so there are no
@@ -25,12 +25,21 @@ const OPCODE = Object.freeze({
     DISPATCH: 0,
     HEARTBEAT: 1,
     IDENTIFY: 2,
+    // "Presence Update" — the opcode the gateway accepts for user-account
+    // presence updates (the same one discord.js sends). Older docs called
+    // this same opcode "Status Update".
+    PRESENCE_UPDATE: 3,
+    // "Voice State Update" per the docs (join/move/leave voice channels) —
+    // NOT a presence opcode. Sending a presence payload on op 4 fails with
+    // 4002 "Error while decoding payload": every shape fails, even
+    // {status} alone (verified with scripts/diag-4002.js). Kept only so the
+    // mistake isn't repeated.
+    VOICE_STATE_UPDATE: 4,
     RESUME: 6,
     RECONNECT: 7,
     INVALID_SESSION: 9,
     HELLO: 10,
     HEARTBEAT_ACK: 11,
-    PRESENCE_UPDATE: 4,
 });
 
 /** Intents requested at IDENTIFY time: GUILDS (1) | GUILD_PRESENCES (8). */
@@ -116,7 +125,13 @@ class DiscordGateway extends EventEmitter {
     }
 
     /**
-     * Update this account's presence status (opcode 4, Update Status).
+     * Update this account's presence status (opcode 3, Presence Update).
+     *
+     * Note: opcode 4 is "Voice State Update" per the docs (join/move/leave
+     * voice channels), not a presence opcode — the gateway rejects presence
+     * payloads on it with 4002 "Error while decoding payload" for user
+     * sessions, every shape included (see scripts/diag-4002.js). Opcode 3 is
+     * what working clients such as discord.js send.
      * @param {PresenceStatus} status New status.
      * @param {boolean} [afk] Whether to mark the account AFK. Mostly
      *   cosmetic for user accounts.
@@ -135,13 +150,11 @@ class DiscordGateway extends EventEmitter {
             op: OPCODE.PRESENCE_UPDATE,
             d: {
                 status,
+                // Mirror the known-good client (discord.js): null while
+                // online, a timestamp of when the status started otherwise.
+                since: status === "online" ? null : Date.now(),
                 afk,
-                since: 0,
                 activities: [],
-                // Match the official desktop client's frame shape exactly.
-                // The minimal payload (since: null, no client_status)
-                // triggered 4002 "Error while decoding payload" closes.
-                client_status: { web: false, desktop: true, mobile: false },
             },
         });
         this.emit("presence-set", status);

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -242,14 +242,19 @@ class DiscordGateway extends EventEmitter {
         try {
             packet = JSON.parse(raw);
         } catch {
-            console.log(`[gw] <- non-JSON frame: ${String(raw).slice(0, 120)}`);
+            // Diagnostics, commented out (uncomment to inspect traffic):
+            // console.log(`[gw] <- non-JSON frame: ${String(raw).slice(0, 120)}`);
             return;
         }
-        // Diagnostics: log protocol frames (opcodes, READY, RESUMED, ...).
-        // High-volume guild/presence dispatches are suppressed.
-        if (packet.op !== 0 || !QUIET_DISPATCHES.has(packet.t)) {
-            console.log(`[gw] <- op=${packet.op}${packet.t ? ` t=${packet.t}` : ""}`);
+        // Diagnostics (minimized): log heartbeat ACKs only — enough to see
+        // the connection stay alive. The full frame dump below is commented
+        // out now that the 4002 debugging is done.
+        if (packet.op === OPCODE.HEARTBEAT_ACK) {
+            console.log(`[gw] <- heartbeat ack`);
         }
+        // if (packet.op !== 0 || !QUIET_DISPATCHES.has(packet.t)) {
+        //     console.log(`[gw] <- op=${packet.op}${packet.t ? ` t=${packet.t}` : ""}`);
+        // }
         if (typeof packet.s === "number") this.seq = packet.s;
 
         switch (packet.op) {
@@ -473,8 +478,13 @@ class DiscordGateway extends EventEmitter {
     #send(payload) {
         if (this.ws && this.ws.readyState === 1 /* OPEN */) {
             const raw = JSON.stringify(payload);
-            // Diagnostics: log every frame we send, token redacted.
-            console.log(`[gw] -> ${this.token ? raw.split(this.token).join("<token>") : raw}`);
+            // Diagnostics (minimized): log heartbeats only. The full frame
+            // dump below (token redacted) is commented out; uncomment to
+            // inspect protocol traffic again.
+            if (payload.op === OPCODE.HEARTBEAT) {
+                console.log(`[gw] -> heartbeat (seq=${this.seq})`);
+            }
+            // console.log(`[gw] -> ${this.token ? raw.split(this.token).join("<token>") : raw}`);
             this.ws.send(raw);
         }
     }

--- a/scripts/diag-4002.js
+++ b/scripts/diag-4002.js
@@ -11,6 +11,9 @@
  *   node scripts/diag-4002.js docs        # documented Update Status shape, no client_status
  *   node scripts/diag-4002.js current     # the app's pre-9fa039b frame (afk:true, since:null)
  *   node scripts/diag-4002.js official    # the app's current frame (with client_status)
+ *   node scripts/diag-4002.js op3         # documented Presence Update OPCODE (3) — every
+ *                                         # op 4 variant above dies with 4002, so the opcode
+ *                                         # itself is the suspect (discord.js uses op 3)
  *
  * NOTE: run with the app container STOPPED. The app's reconnect loop creates
  * a fresh session every few seconds, and the server may refuse new sessions
@@ -35,8 +38,8 @@ const OBSERVE_MS = 120_000;
 const PRESENCE_VARIANTS = {
     // Absolute minimum: just the status field.
     minimal: { status: "online" },
-    // The documented Update Status shape (status/since/activities/afk),
-    // WITHOUT client_status (not a documented op 4 field).
+    // The documented presence payload shape (status/since/activities/afk),
+    // WITHOUT client_status (not a documented presence field).
     docs: { status: "online", afk: false, since: 0, activities: [] },
     // The app's frame before 9fa039b (afk leftover true, since null).
     current: { status: "online", afk: true, since: null, activities: [] },
@@ -51,8 +54,8 @@ const PRESENCE_VARIANTS = {
 };
 
 const mode = process.argv[2];
-if (!mode || !(mode === "none" || mode in PRESENCE_VARIANTS)) {
-    console.error("usage: node scripts/diag-4002.js none|current|official");
+if (!mode || !(mode === "none" || mode === "op3" || mode in PRESENCE_VARIANTS)) {
+    console.error("usage: node scripts/diag-4002.js none|minimal|docs|current|official|op3");
     process.exit(2);
 }
 const token = process.env.TOKEN;
@@ -126,9 +129,15 @@ const t0 = Date.now();
             ready = true;
             log(`READY (session ${p.d.session_id}, user ${p.d.user.username})`);
             if (mode !== "none") {
-                const frame = { op: 4, d: PRESENCE_VARIANTS[mode] };
+                // op3 mode: the documented "Presence Update" opcode (3) with
+                // the payload shape discord.js sends (since:null when online).
+                // All op 4 (Voice State Update) variants die with 4002 — the
+                // opcode, not the payload, is under test here.
+                const frame = mode === "op3"
+                    ? { op: 3, d: { status: "online", since: null, afk: false, activities: [] } }
+                    : { op: 4, d: PRESENCE_VARIANTS[mode] };
                 ws.send(JSON.stringify(frame));
-                log(`-> op 4 presence [${mode}]: ${JSON.stringify(frame.d)}`);
+                log(`-> op ${frame.op} presence [${mode}]: ${JSON.stringify(frame.d)}`);
             } else {
                 log("mode=none: intentionally sending NO presence update");
             }

--- a/scripts/diag-4002.js
+++ b/scripts/diag-4002.js
@@ -4,7 +4,10 @@
  * One-off diagnostic: isolate what triggers the 4002 ("decode error") close
  * that happens a few seconds after READY.
  *
- * Usage (inside the container image; token comes from the baked-in .env):
+ * Usage (inside the container image; the token is passed at runtime — it
+ * is no longer baked into the image, see .dockerignore):
+ *
+ *   docker run --rm --env-file .env <image> node scripts/diag-4002.js <mode>
  *
  *   node scripts/diag-4002.js none        # connect + READY, send NO presence update (control)
  *   node scripts/diag-4002.js minimal     # op 4 with only {status}

--- a/scripts/diag-4002.js
+++ b/scripts/diag-4002.js
@@ -6,9 +6,15 @@
  *
  * Usage (inside the container image; token comes from the baked-in .env):
  *
- *   node scripts/diag-4002.js none        # connect + READY, send NO presence update
- *   node scripts/diag-4002.js current     # send the app's exact op 4 payload
- *   node scripts/diag-4002.js official    # send an official-client-shaped op 4
+ *   node scripts/diag-4002.js none        # connect + READY, send NO presence update (control)
+ *   node scripts/diag-4002.js minimal     # op 4 with only {status}
+ *   node scripts/diag-4002.js docs        # documented Update Status shape, no client_status
+ *   node scripts/diag-4002.js current     # the app's pre-9fa039b frame (afk:true, since:null)
+ *   node scripts/diag-4002.js official    # the app's current frame (with client_status)
+ *
+ * NOTE: run with the app container STOPPED. The app's reconnect loop creates
+ * a fresh session every few seconds, and the server may refuse new sessions
+ * (op 9, no READY) for an account that churns sessions that fast.
  *
  * The IDENTIFY frame is byte-identical to lib/discord-gateway.js. After
  * READY (and the optional presence update) it only heartbeats and observes
@@ -27,9 +33,14 @@ const OBSERVE_MS = 120_000;
 
 /** Presence payloads under test. */
 const PRESENCE_VARIANTS = {
-    // Exactly what the app sends today (index.js always passes afk=true).
+    // Absolute minimum: just the status field.
+    minimal: { status: "online" },
+    // The documented Update Status shape (status/since/activities/afk),
+    // WITHOUT client_status (not a documented op 4 field).
+    docs: { status: "online", afk: false, since: 0, activities: [] },
+    // The app's frame before 9fa039b (afk leftover true, since null).
     current: { status: "online", afk: true, since: null, activities: [] },
-    // Shaped like the official desktop client's Update Status frame.
+    // The app's frame today (9fa039b): adds client_status.
     official: {
         status: "online",
         afk: false,
@@ -89,6 +100,7 @@ const t0 = Date.now();
         }
         if (p.op === 10) {
             // HELLO
+            clearTimeout(helloTimeout);
             heartbeatMs = p.d.heartbeat_interval;
             setInterval(() => {
                 ws.send(JSON.stringify({ op: 1, d: null }));
@@ -134,8 +146,11 @@ const t0 = Date.now();
     };
     ws.onerror = () => { /* onclose follows */ };
 
-    setTimeout(() => {
+    // Give up if HELLO never arrives. Must be cleared once HELLO does —
+    // otherwise it kills the observation at 15s (see: the first diag round).
+    const helloTimeout = setTimeout(() => {
         log("gave up waiting for HELLO");
         process.exit(1);
-    }, 15_000).unref();
+    }, 15_000);
+    helloTimeout.unref?.();
 })();

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -73,7 +73,7 @@ class MockWebSocket {
             case 1: // HEARTBEAT
                 this.push({ op: 11, d: null });
                 break;
-            case 4: // PRESENCE_UPDATE — echo the server's view
+            case 3: // PRESENCE_UPDATE — echo the server's view
                 this.push({
                     op: 0, s: 3, t: "PRESENCE_UPDATE",
                     d: { user: { id: MockWebSocket.USER.id }, status: frame.d.status },
@@ -161,24 +161,33 @@ test("setPresence rejects before the socket is open", async () => {
     await assert.rejects(gateway.setPresence("bogus"), /invalid status/);
 });
 
-test("setPresence sends op 4 and tracks the status", async () => {
+test("setPresence sends op 3 (Presence Update) and tracks the status", async () => {
     const gateway = await connectReady();
     const socket = MockWebSocket.instances.at(-1);
 
+    const before = Date.now();
     await gateway.setPresence("dnd", false);
+    const after = Date.now();
 
+    // Regression: opcode 4 ("Voice State Update") is not a presence opcode —
+    // the gateway rejects presence payloads on it with 4002 for user
+    // sessions. Presence must go out on opcode 3.
     const frame = socket.sent.at(-1);
-    assert.deepEqual(frame, {
-        op: 4,
-        d: {
-            status: "dnd",
-            afk: false,
-            since: 0,
-            activities: [],
-            client_status: { web: false, desktop: true, mobile: false },
-        },
-    });
+    assert.equal(frame.op, 3);
+    assert.equal(frame.d.status, "dnd");
+    assert.equal(frame.d.afk, false);
+    assert.deepEqual(frame.d.activities, []);
+    assert.ok(
+        frame.d.since >= before && frame.d.since <= after,
+        "non-online status carries a since timestamp"
+    );
     assert.equal(gateway.status, "dnd");
+
+    await gateway.setPresence("online", false);
+    const onlineFrame = socket.sent.at(-1);
+    assert.equal(onlineFrame.op, 3);
+    assert.equal(onlineFrame.d.since, null, "online sends since:null like the working client");
+    assert.equal(gateway.status, "online");
     gateway.disconnect();
 });
 
@@ -227,7 +236,7 @@ test("resumes the session after a reconnect (no re-identify)", async () => {
     assert.ok(resume, "expected a RESUME frame");
     assert.equal(resume.d.token, "token-123");
     assert.equal(resume.d.session_id, "session-1");
-    // READY is s:1; the mock's PRESENCE_UPDATE echo for the op-4 frame is s:3.
+    // READY is s:1; the mock's PRESENCE_UPDATE echo for the op-3 frame is s:3.
     assert.equal(resume.d.seq, 3);
     assert.ok(!secondSocket.sent.some((f) => f.op === 2), "must not re-IDENTIFY");
     assert.equal(gateway.status, "idle"); // presence survived the resume


### PR DESCRIPTION
## Summary

Fixes the 4002 "Error while decoding payload" gateway closes that killed the session a few seconds after READY, plus two small cleanups found while validating the fix.

## Changes

### fix: send presence updates on op 3 (Presence Update), not op 4
- Per the gateway docs, opcode 4 is **Voice State Update** (join/move/leave voice channels), not a presence opcode — presence payloads on it fail to decode, which is what produced the 4002 closes for every payload shape (verified with `scripts/diag-4002.js`).
- Presence now goes out on op 3 ("Presence Update"; older docs called it "Status Update" — the source of the original mix-up), the same opcode discord.js sends, with `since: null` while online and a timestamp otherwise.
- Renamed the op 4 constant to `VOICE_STATE_UPDATE`, corrected the "Update Status" mislabeling in code comments, and fixed `docs/plan-native-gateway.md`, which carried the original op 4 mistake.
- Added an `op3` mode to `scripts/diag-4002.js` for live verification.

### chore: minimize gateway logs to heartbeats
- The 4002 debugging is done: the per-frame inbound/outbound dumps are commented out (not deleted) and replaced with heartbeat send/ack lines only, so connection liveness is still visible.

### fix: stop status label rendering as a solid color block
- The status tint rules painted the "Current status" label's background as well as its text, rendering it as a solid green/yellow/red block. The avatar dot keeps the background fill; the label only gets the text color.

## Validation

- `node --test`: 14/14 pass (mock-gateway protocol tests, including a regression test that presence goes out on op 3).
- Live: `node scripts/diag-4002.js op3` survived the full 120s observation with no 4002, and the app has been running stable overnight with status changes working.
