### PR TITLE
fix: honor isAfk so the account reads as away (restores mobile pushes)

### DIFF
--- a/docs/plan-native-gateway.md
+++ b/docs/plan-native-gateway.md
@@ -36,8 +36,9 @@ A small `DiscordGateway` class extending `EventEmitter`:
   `HEARTBEAT ACK` (op 11) arrives within 2× the interval, force a reconnect.
 - `setPresence(status, afk)` → send op 3
   `{"status": <s>, "afk": <a>, "since": null | <now>, "activities": []}`
-  (`since` is `null` while online, a timestamp of when the status started
-  otherwise).
+  (`since` is `null` only while online and not away, a timestamp of when the
+  state started otherwise — the away-since timestamp is what makes Discord's
+  mobile app send push notifications).
   Rejects if not connected. Resolves once the frame is sent.
 - Status tracking: `this.status` is set optimistically by `setPresence` and
   reconciled from `PRESENCE_UPDATE` dispatches for our own user id.
@@ -74,8 +75,7 @@ no real token needed.
 ## Out of scope
 - ToS status is unchanged: a personal token over the Gateway is still a
   self-bot (see README). This only removes the old library.
-- Sharding (never used), compression, activity/emoji presence, afk push
-  notifications.
+- Sharding (never used), compression, activity/emoji presence.
 
 ## Commit cadence
 1. Plan (this file)

--- a/index.js
+++ b/index.js
@@ -54,17 +54,19 @@ app.get('/api/getStatus', async (req, res) => {
 });
 
 // update the status {newStatus: "status", isAfk: bool}
-// isAfk maps to the afk field of the op 3 presence frame. It is a leftover
-// from the python version and is always false now (matches the official
-// client); the UI's isAfk flag is accepted but intentionally ignored.
+// isAfk maps to the afk field of the op 3 presence frame. Discord uses it
+// to decide whether the account is "away": with afk:true the mobile app
+// resumes push notifications even while the account stays online. The UI
+// sends isAfk:true on every change for exactly that reason.
 app.post('/api/updateStatus', async (req, res) => {
     try {
         // {newStatus: status, isAfk: true}
         console.log("POST: /api/updateStatus")
         const payload = req.body;
         const status = payload.newStatus;
+        const isAfk = payload.isAfk === true;
         // TODO: set the status here to resume from on internet outage
-        await changeStatus(status);
+        await changeStatus(status, isAfk);
         res.send(`changed status to ${status}`, 200);
     } catch {
         res.status(500);
@@ -76,9 +78,9 @@ app.post('/api/updateStatus', async (req, res) => {
 /**
  * change status
  * @param {string} newStatus 'online', 'idle', 'dnd', 'invisible'
- * @param {boolean} [isAfk] the afk field of the op 3 frame; keep false,
- *   matching the official client (afk:true is a leftover that does nothing
- *   useful for this app)
+ * @param {boolean} [isAfk] the afk field of the op 3 frame. true marks the
+ *   account away — the state that makes the mobile app send push
+ *   notifications (the official client sends the same frame when away).
  */
 const changeStatus = async (newStatus, isAfk = false) => {
     // 'online', 'idle', 'dnd', 'invisible'

--- a/lib/discord-gateway.js
+++ b/lib/discord-gateway.js
@@ -133,8 +133,9 @@ class DiscordGateway extends EventEmitter {
      * sessions, every shape included (see scripts/diag-4002.js). Opcode 3 is
      * what working clients such as discord.js send.
      * @param {PresenceStatus} status New status.
-     * @param {boolean} [afk] Whether to mark the account AFK. Mostly
-     *   cosmetic for user accounts.
+     * @param {boolean} [afk] Whether to mark the account away. With true,
+     *   Discord treats the account as away from all devices, which is what
+     *   makes the mobile app send push notifications.
      * @returns {Promise<void>} Resolves once the frame has been sent.
      * @throws {Error} If the status is invalid or the socket is not open.
      */
@@ -150,9 +151,11 @@ class DiscordGateway extends EventEmitter {
             op: OPCODE.PRESENCE_UPDATE,
             d: {
                 status,
-                // Mirror the known-good client (discord.js): null while
-                // online, a timestamp of when the status started otherwise.
-                since: status === "online" ? null : Date.now(),
+                // Mirror the known-good client (discord.js): null only while
+                // online AND not away, a timestamp of when the state started
+                // otherwise — including online+afk, where the "away since"
+                // timestamp is what makes mobile push notifications fire.
+                since: status === "online" && !afk ? null : Date.now(),
                 afk,
                 activities: [],
             },

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -191,6 +191,30 @@ test("setPresence sends op 3 (Presence Update) and tracks the status", async () 
     gateway.disconnect();
 });
 
+test("setPresence online+afk sends a since timestamp (away state)", async () => {
+    const gateway = await connectReady();
+    const socket = MockWebSocket.instances.at(-1);
+
+    const before = Date.now();
+    await gateway.setPresence("online", true);
+    const after = Date.now();
+
+    // Regression: afk:true is what makes Discord's mobile app send push
+    // notifications. Like the official client and discord.js, the away
+    // state must carry an "away since" timestamp even while the status is
+    // online — since:null + afk:true is a state the official client never
+    // sends, and the account would not read as away.
+    const frame = socket.sent.at(-1);
+    assert.equal(frame.op, 3);
+    assert.equal(frame.d.status, "online");
+    assert.equal(frame.d.afk, true);
+    assert.ok(
+        frame.d.since >= before && frame.d.since <= after,
+        "online+afk carries a since timestamp"
+    );
+    gateway.disconnect();
+});
+
 test("server PRESENCE_UPDATE reconciles the tracked status", async () => {
     const gateway = await connectReady();
     const socket = MockWebSocket.instances.at(-1);

--- a/test/http-surface.test.js
+++ b/test/http-surface.test.js
@@ -130,6 +130,19 @@ test("after ready: default status is online and updateStatus changes it", async 
     assert.deepEqual(StubGateway.instance.presenceCalls.at(-1), ["dnd", false]);
 });
 
+test("updateStatus passes isAfk through to setPresence", async () => {
+    // Regression: the UI sends isAfk:true on every status change so the
+    // account reads as away and mobile push notifications keep firing. The
+    // handler must not drop the flag (it did, which silenced pushes).
+    const res = await fetch(`${base}/api/updateStatus`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newStatus: "online", isAfk: true }),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(StubGateway.instance.presenceCalls.at(-1), ["online", true]);
+});
+
 test("process survives the gateway emitting 'error' (reconnect failure)", async () => {
     // index.js must listen for 'error': without a listener the
     // EventEmitter throws and the process crashes on a failed reconnect.


### PR DESCRIPTION
## Problem

Since the 4002 debugging, `/api/updateStatus` silently dropped the `isAfk`
flag that the UI sends on every status change (`app.js` posts
`{ newStatus, isAfk: true }`), so every op 3 presence frame went out with
`afk: false`. Discord reads `afk: false` as "active on this device" and
suppresses mobile push notifications — the account has to be away
(`afk: true`) for the phone to push. Result: the spoofer held the status
fine, but no pushes arrived on mobile.

The flag was force-dropped in 9fa039b as part of matching the
"official-client shape" while chasing 4002 closes, but the actual cause
was the opcode (op 4 → op 3, fixed in 2c016f8). The app has been stable on
op 3 for a day, and `afk: true` is a value the official client itself
sends when away (see discord.js-selfbot-v13 discussion #464 —
`setAFK(true)` while online is the known-working recipe for pushes).

## Changes

- **index.js** — pass `payload.isAfk` through to `changeStatus()`. The
  frontend already sends `isAfk: true`, so this alone restores pushes.
  `lastAfk` is already persisted and re-sent on `resumed`, so it survives
  reconnects.
- **lib/discord-gateway.js** — `since` is now a timestamp whenever `afk`
  is true, even for status `online` (was `null` for all online frames).
  The away-since timestamp is what makes the account read as away; both
  the official client and discord.js send it, and `since: null` +
  `afk: true` is a state the official client never emits.
- **tests** — new http-surface test asserting `isAfk` reaches
  `setPresence`; new gateway test asserting online+afk carries a `since`
  timestamp. Full suite: 16/16 passing, no network/token needed.
- **docs/plan-native-gateway.md** — corrected the now-false "afk does
  nothing useful" framing and the out-of-scope note.

## Verification

- `npm test` — 16 pass / 0 fail.
- Runtime (post-merge, on the running container): set a status from the
  UI, then have someone DM the account — expect a mobile push after the
  guild's `afk_timeout` (Discord setting, 30–600 s, default 30 s). Watch
  `docker logs` for a close code 4002 right after the status change
  (should not happen; the 4002 was the op 4 issue, and `afk: true` is
  official-client-shaped).
